### PR TITLE
update size and position in auto layout's layout pass

### DIFF
--- a/UIView+MGBadgeView.m
+++ b/UIView+MGBadgeView.m
@@ -73,6 +73,13 @@ static int const kMGBadgeViewTag = 9876;
     }
 }
 
+- (void)layoutSubviews {
+    [super layoutSubviews];
+
+    [self mg_updateBadgeViewSize];
+    [self mg_updateBadgeViewPosition];
+}
+
 #pragma mark - Properties accessor methods
 
 - (void)setBadgeValue:(NSInteger)badgeValue {


### PR DESCRIPTION
* this fixes the badgeViews use with auto layout - especially within tableview where the badgeview jumped around and varied its size when scrolling 
* it is simply triggering recalculation of size and position in layoutSubviews